### PR TITLE
Preload all the card images when the game starts

### DIFF
--- a/src/Card.jsx
+++ b/src/Card.jsx
@@ -13,7 +13,7 @@ export default function Card(props) {
           : "white",
       }}
     >
-      {props.isFlipped && <img src={props.imageUrl} alt={props.value} />}
+      <img src={props.imageUrl} alt={props.value} style={{display: props.isFlipped ? 'block' : 'none'}} />
     </div>
   );
 }


### PR DESCRIPTION
Changed Card to add the image to the DOM immediately when mounted. Thus, the game preloads all the card images.

Closes #16